### PR TITLE
Use dedicated Enum type error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,4 +9,4 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,7 @@ jobs:
           target: ${{ matrix.environment.target }}
           override: true
       - name: Install system packages
-        if: ${{ matrix.environment.packages }}
+        if: matrix.environment.packages
         run: sudo apt-get install -qq ${{ matrix.environment.packages }}
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,9 @@ jobs:
           override: true
       - name: Install system packages
         if: matrix.environment.packages
-        run: sudo apt-get install -qq ${{ matrix.environment.packages }}
+        run: |
+            sudo apt-get update;
+            sudo apt-get install -qq ${{ matrix.environment.packages }};
       - uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.environment.cross }}

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -42,10 +42,12 @@ pub enum JWTDecodeError {
 impl fmt::Display for JWTDecodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            JWTDecodeError::MissingSection() => write!(f, "{}", "Missing token section".to_string()),
-            JWTDecodeError::InvalidUtf8(e) => e.fmt(f),
-            JWTDecodeError::InvalidBase64(e) => e.fmt(f),
-            JWTDecodeError::InvalidJSON(e) => e.fmt(f),
+            JWTDecodeError::MissingSection() => {
+                write!(f, "{}", "Missing token section".to_string())
+            }
+            JWTDecodeError::InvalidUtf8(e) => write!(f, "UTF8 error, {}", e),
+            JWTDecodeError::InvalidBase64(e) => write!(f, "Base64 error, {}", e),
+            JWTDecodeError::InvalidJSON(e) => write!(f, "JSON error, {}", e),
         }
     }
 }

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -42,7 +42,7 @@ pub enum JWTDecodeError {
 impl fmt::Display for JWTDecodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            JWTDecodeError::MissingSection() => write!(f, "{}", format!("Missing token section")),
+            JWTDecodeError::MissingSection() => write!(f, "{}", "Missing token section".to_string()),
             JWTDecodeError::InvalidUtf8(e) => e.fmt(f),
             JWTDecodeError::InvalidBase64(e) => e.fmt(f),
             JWTDecodeError::InvalidJSON(e) => e.fmt(f),
@@ -85,7 +85,7 @@ impl fmt::Display for JWTDecodePartError {
                 write!(f, "{}", format!("Invalid Signature: {}", e))
             }
             JWTDecodePartError::UnexpectedPart() => {
-                write!(f, "{}", format!("Unexpected fragment after signature"))
+                write!(f, "{}", "Unexpected fragment after signature".to_string())
             }
         }
     }
@@ -123,9 +123,9 @@ fn parse_signature(raw_signature: Option<&str>) -> Result<Vec<u8>, JWTDecodeErro
 
 pub fn parse_token(token: &str) -> Result<Token, JWTDecodePartError> {
     let mut parts = token.split('.');
-    let header = parse_header(parts.next()).map_err(|e| JWTDecodePartError::Header(e))?;
-    let body = parse_body(parts.next()).map_err(|e| JWTDecodePartError::Body(e))?;
-    let signature = parse_signature(parts.next()).map_err(|e| JWTDecodePartError::Signature(e))?;
+    let header = parse_header(parts.next()).map_err(JWTDecodePartError::Header)?;
+    let body = parse_body(parts.next()).map_err(JWTDecodePartError::Body)?;
+    let signature = parse_signature(parts.next()).map_err(JWTDecodePartError::Signature)?;
 
     if parts.next().is_some() {
         return Err(JWTDecodePartError::UnexpectedPart());

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -33,7 +33,7 @@ impl Token {
 
 #[derive(Debug)]
 pub enum JWTDecodeError {
-    MissingSection(String),
+    MissingSection(),
     InvalidUtf8(str::Utf8Error),
     InvalidBase64(base64::DecodeError),
     InvalidJSON(serde_json::error::Error),
@@ -42,9 +42,7 @@ pub enum JWTDecodeError {
 impl fmt::Display for JWTDecodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            JWTDecodeError::MissingSection(s) => {
-                write!(f, "{}", format!("Missing token section: {}", s))
-            }
+            JWTDecodeError::MissingSection() => write!(f, "{}", format!("Missing token section")),
             JWTDecodeError::InvalidUtf8(e) => e.fmt(f),
             JWTDecodeError::InvalidBase64(e) => e.fmt(f),
             JWTDecodeError::InvalidJSON(e) => e.fmt(f),
@@ -70,35 +68,68 @@ impl From<serde_json::error::Error> for JWTDecodeError {
     }
 }
 
+#[derive(Debug)]
+pub enum JWTDecodePartError {
+    Header(JWTDecodeError),
+    Body(JWTDecodeError),
+    Signature(JWTDecodeError),
+    UnexpectedPart(),
+}
+
+impl fmt::Display for JWTDecodePartError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            JWTDecodePartError::Header(e) => write!(f, "{}", format!("Invalid Header: {}", e)),
+            JWTDecodePartError::Body(e) => write!(f, "{}", format!("Invalid Body: {}", e)),
+            JWTDecodePartError::Signature(e) => {
+                write!(f, "{}", format!("Invalid Signature: {}", e))
+            }
+            JWTDecodePartError::UnexpectedPart() => {
+                write!(f, "{}", format!("Unexpected fragment after signature"))
+            }
+        }
+    }
+}
+
 fn parse_base64_string(s: &str) -> Result<String, JWTDecodeError> {
     let s = base64::decode_config(s, *BASE64_CONFIG)?;
     let s = str::from_utf8(&s)?;
     Ok(s.to_string())
 }
 
-pub fn parse_token(token: &str) -> Result<Token, JWTDecodeError> {
-    let mut parts = token.split('.');
-
-    // header
-    let header = match parts.next() {
-        None => return Err(JWTDecodeError::MissingSection("header".to_string())),
+fn parse_header(raw_header: Option<&str>) -> Result<Header, JWTDecodeError> {
+    match raw_header {
+        None => return Err(JWTDecodeError::MissingSection()),
         Some(s) => {
             let header_str = parse_base64_string(s)?;
-            serde_json::from_str(&header_str)?
+            Ok(serde_json::from_str::<Header>(&header_str)?)
         }
-    };
+    }
+}
 
-    // body
-    let body = match parts.next() {
-        None => return Err(JWTDecodeError::MissingSection("body".to_string())),
-        Some(s) => parse_base64_string(s)?,
-    };
+fn parse_body(raw_body: Option<&str>) -> Result<String, JWTDecodeError> {
+    match raw_body {
+        None => return Err(JWTDecodeError::MissingSection()),
+        Some(s) => Ok(parse_base64_string(s)?),
+    }
+}
 
-    // signature
-    let signature = match parts.next() {
-        None => return Err(JWTDecodeError::MissingSection("signature".to_string())),
-        Some(s) => base64::decode_config(s, *BASE64_CONFIG)?,
-    };
+fn parse_signature(raw_signature: Option<&str>) -> Result<Vec<u8>, JWTDecodeError> {
+    match raw_signature {
+        None => return Err(JWTDecodeError::MissingSection()),
+        Some(s) => Ok(base64::decode_config(s, *BASE64_CONFIG)?),
+    }
+}
+
+pub fn parse_token(token: &str) -> Result<Token, JWTDecodePartError> {
+    let mut parts = token.split('.');
+    let header = parse_header(parts.next()).map_err(|e| JWTDecodePartError::Header(e))?;
+    let body = parse_body(parts.next()).map_err(|e| JWTDecodePartError::Body(e))?;
+    let signature = parse_signature(parts.next()).map_err(|e| JWTDecodePartError::Signature(e))?;
+
+    if parts.next().is_some() {
+        return Err(JWTDecodePartError::UnexpectedPart());
+    }
 
     Ok(Token::new(header, body, signature))
 }

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -1,5 +1,6 @@
 use base64;
 use serde::Deserialize;
+use std::fmt;
 use std::str;
 
 lazy_static! {
@@ -30,49 +31,73 @@ impl Token {
     }
 }
 
-fn parse_base64_string(s: &str) -> Result<String, String> {
-    match base64::decode_config(s, *BASE64_CONFIG) {
-        Ok(s) => match str::from_utf8(&s) {
-            Ok(s) => Ok(s.to_string()),
-            Err(e) => Err(format!("cannot be decoded to a valid UTF-8 string. {}", e)),
-        },
-        Err(e) => Err(format!("is not a valid base64 string. {}", e)),
+#[derive(Debug)]
+pub enum JWTDecodeError {
+    MissingSection(String),
+    InvalidUtf8(str::Utf8Error),
+    InvalidBase64(base64::DecodeError),
+    InvalidJSON(serde_json::error::Error),
+}
+
+impl fmt::Display for JWTDecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            JWTDecodeError::MissingSection(s) => {
+                write!(f, "{}", format!("Missing token section: {}", s))
+            }
+            JWTDecodeError::InvalidUtf8(e) => e.fmt(f),
+            JWTDecodeError::InvalidBase64(e) => e.fmt(f),
+            JWTDecodeError::InvalidJSON(e) => e.fmt(f),
+        }
     }
 }
 
-pub fn parse_token(token: &str) -> Result<Token, String> {
-    let parts: Vec<&str> = token.split('.').collect();
-    let header_str = match parts.get(0) {
-        Some(s) => match parse_base64_string(s) {
-            Ok(s) => s,
-            Err(e) => return Err(format!("Malformed JWT: Header {}", e)),
-        },
-        None => return Err("Malformed JWT: Header is missing".to_string()),
-    };
-    let header: Header = match serde_json::from_str(&header_str) {
-        Ok(h) => h,
-        Err(e) => return Err(format!("Malformed JWT: Header is not a valid JSON. {}", e)),
+impl From<str::Utf8Error> for JWTDecodeError {
+    fn from(err: str::Utf8Error) -> JWTDecodeError {
+        JWTDecodeError::InvalidUtf8(err)
+    }
+}
+
+impl From<base64::DecodeError> for JWTDecodeError {
+    fn from(err: base64::DecodeError) -> JWTDecodeError {
+        JWTDecodeError::InvalidBase64(err)
+    }
+}
+
+impl From<serde_json::error::Error> for JWTDecodeError {
+    fn from(err: serde_json::error::Error) -> JWTDecodeError {
+        JWTDecodeError::InvalidJSON(err)
+    }
+}
+
+fn parse_base64_string(s: &str) -> Result<String, JWTDecodeError> {
+    let s = base64::decode_config(s, *BASE64_CONFIG)?;
+    let s = str::from_utf8(&s)?;
+    Ok(s.to_string())
+}
+
+pub fn parse_token(token: &str) -> Result<Token, JWTDecodeError> {
+    let mut parts = token.split('.');
+
+    // header
+    let header = match parts.next() {
+        None => return Err(JWTDecodeError::MissingSection("header".to_string())),
+        Some(s) => {
+            let header_str = parse_base64_string(s)?;
+            serde_json::from_str(&header_str)?
+        }
     };
 
-    let body = match parts.get(1) {
-        Some(s) => match parse_base64_string(s) {
-            Ok(s) => s,
-            Err(e) => return Err(format!("Malformed JWT: Body {}", e)),
-        },
-        None => return Err("Malformed JWT: Body is missing".to_string()),
+    // body
+    let body = match parts.next() {
+        None => return Err(JWTDecodeError::MissingSection("body".to_string())),
+        Some(s) => parse_base64_string(s)?,
     };
 
-    let signature = match parts.get(2) {
-        Some(s) => match base64::decode_config(s, *BASE64_CONFIG) {
-            Ok(v) => v,
-            Err(e) => {
-                return Err(format!(
-                    "Malformed JWT: cannot decode signature from base64. {}",
-                    e
-                ))
-            }
-        },
-        None => return Err("Malformed JWT: Missing signature".to_string()),
+    // signature
+    let signature = match parts.next() {
+        None => return Err(JWTDecodeError::MissingSection("signature".to_string())),
+        Some(s) => base64::decode_config(s, *BASE64_CONFIG)?,
     };
 
     Ok(Token::new(header, body, signature))

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -86,9 +86,11 @@ impl fmt::Display for JWTDecodePartError {
             JWTDecodePartError::Signature(e) => {
                 write!(f, "{}", format!("Invalid Signature: {}", e))
             }
-            JWTDecodePartError::UnexpectedPart() => {
-                write!(f, "{}", "Unexpected fragment after signature".to_string())
-            }
+            JWTDecodePartError::UnexpectedPart() => write!(
+                f,
+                "{}",
+                "Error: Unexpected fragment after signature".to_string()
+            ),
         }
     }
 }

--- a/src/jwt/mod.rs
+++ b/src/jwt/mod.rs
@@ -99,7 +99,7 @@ fn parse_base64_string(s: &str) -> Result<String, JWTDecodeError> {
 
 fn parse_header(raw_header: Option<&str>) -> Result<Header, JWTDecodeError> {
     match raw_header {
-        None => return Err(JWTDecodeError::MissingSection()),
+        None => Err(JWTDecodeError::MissingSection()),
         Some(s) => {
             let header_str = parse_base64_string(s)?;
             Ok(serde_json::from_str::<Header>(&header_str)?)
@@ -109,14 +109,14 @@ fn parse_header(raw_header: Option<&str>) -> Result<Header, JWTDecodeError> {
 
 fn parse_body(raw_body: Option<&str>) -> Result<String, JWTDecodeError> {
     match raw_body {
-        None => return Err(JWTDecodeError::MissingSection()),
+        None => Err(JWTDecodeError::MissingSection()),
         Some(s) => Ok(parse_base64_string(s)?),
     }
 }
 
 fn parse_signature(raw_signature: Option<&str>) -> Result<Vec<u8>, JWTDecodeError> {
     match raw_signature {
-        None => return Err(JWTDecodeError::MissingSection()),
+        None => Err(JWTDecodeError::MissingSection()),
         Some(s) => Ok(base64::decode_config(s, *BASE64_CONFIG)?),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod jwt;
 
 fn main() {
     let matches = App::new("jwtinfo")
-        .version("0.1.0")
+        .version(env!("CARGO_PKG_VERSION"))
         .about("Shows information about a JWT token")
         .arg(
             Arg::with_name("token")
@@ -22,7 +22,7 @@ fn main() {
     let jwt_token = match jwt::parse_token(token) {
         Ok(t) => t,
         Err(e) => {
-            eprintln!("{}", e);
+            eprintln!("Error: {}", e);
             process::exit(1);
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     let jwt_token = match jwt::parse_token(token) {
         Ok(t) => t,
         Err(e) => {
-            eprintln!("Error: {}", e);
+            eprintln!("{}", e);
             process::exit(1);
         }
     };


### PR DESCRIPTION
Closes #7

The current implementation greatly improves the code as it removes nested `match` statement.
At the same time, this implementation has a shortcoming. Errors become a bit more generic as we are not able anymore to tell which component of the token (header, body or signature) is failing.

## Issue with this change

I couldn't figure out a non-complicated way to achieve that, so happy to accept advice in that sense.

Just to clarify, this is the current issue:

**Token with broken header**

```bash
./target/release/jwtinfo eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9x.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
Error: Encoded text cannot have a 6-bit remainder.
```

**Token with broken body**

```bash
./target/release/jwtinfo eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQx.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
Error: Encoded text cannot have a 6-bit remainder.
```

**Token with broken signature**

```bash
./target/release/jwtinfo "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMexxxxxxxxKKF2QT4fwpMeJf36POk6yJV_adQs|sw5cx"
Error: Encoded text cannot have a 6-bit remainder.
```

In the previous version, we would be able to print which part of the token was actually generating the error...

## Bonus changes in this PR:

 - use `env!("CARGO_PKG_VERSION")` to interpolate actual cargo version directly from the `Cargo.toml` file at compile time (the version was never updated before in the help message! 😅). Closes #9 .
 - Updated `.editorconfig` to use `4` spaces per tab as per `cargo fmt`.
 - Avoid allocation by using an iterator to traverse the different token parts.
 - Improves CI setup (no more errors on apt-get install for ARMv7 dependencies)