### PR TITLE
Adds CI integration with codecov

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,0 +1,7 @@
+branch: true
+ignore-not-existing: true
+llvm: true
+filter: covered
+output-type: lcov
+output-file: ./lcov.info
+prefix-dir: /home/user/build/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,3 +95,4 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          file: ${{ steps.coverage.outputs.report }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,71 +9,71 @@ on:
 
 jobs:
 
-  linting:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Clippy
-        run: |
-          rustup component add clippy
-          cargo clippy --all-targets --all-features -- -D warnings
-      - name: Rustfmt
-        run: cargo fmt -- --check
+  # linting:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Clippy
+  #       run: |
+  #         rustup component add clippy
+  #         cargo clippy --all-targets --all-features -- -D warnings
+  #     - name: Rustfmt
+  #       run: cargo fmt -- --check
 
-  test:
-    needs:
-      - linting
-    strategy:
-      matrix:
-        environment:
-          - os: "ubuntu-18.04"
-            target: "x86_64-unknown-linux-gnu"
-            cross: true
-          - os: "macos-10.15"
-            target: "x86_64-apple-darwin"
-            cross: true
-          - os: "ubuntu-18.04"
-            target: "x86_64-pc-windows-gnu"
-            cross: true
-            packages: "gcc-mingw-w64"
-          - os: "ubuntu-18.04"
-            target: "armv7-unknown-linux-gnueabihf"
-            cross: true
-            packages: "gcc-arm-linux-gnueabihf"
-    runs-on: "${{ matrix.environment.os }}"
-    name: "${{ matrix.environment.os }} (${{ matrix.environment.target }})"
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-${{ matrix.environment.target }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-${{ matrix.environment.target }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      - name: Run tests
-        run: cargo test --verbose
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.environment.target }}
-          override: true
-      - name: Install system packages
-        if: matrix.environment.packages
-        run: |
-            sudo apt-get update;
-            sudo apt-get install -qq ${{ matrix.environment.packages }};
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.environment.cross }}
-          command: build
-          args: --release --target ${{ matrix.environment.target }} --verbose
+  # test:
+  #   needs:
+  #     - linting
+  #   strategy:
+  #     matrix:
+  #       environment:
+  #         - os: "ubuntu-18.04"
+  #           target: "x86_64-unknown-linux-gnu"
+  #           cross: true
+  #         - os: "macos-10.15"
+  #           target: "x86_64-apple-darwin"
+  #           cross: true
+  #         - os: "ubuntu-18.04"
+  #           target: "x86_64-pc-windows-gnu"
+  #           cross: true
+  #           packages: "gcc-mingw-w64"
+  #         - os: "ubuntu-18.04"
+  #           target: "armv7-unknown-linux-gnueabihf"
+  #           cross: true
+  #           packages: "gcc-arm-linux-gnueabihf"
+  #   runs-on: "${{ matrix.environment.os }}"
+  #   name: "${{ matrix.environment.os }} (${{ matrix.environment.target }})"
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/cache@v1
+  #       with:
+  #         path: ~/.cargo/registry
+  #         key: ${{ runner.os }}-${{ matrix.environment.target }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+  #     - uses: actions/cache@v1
+  #       with:
+  #         path: target
+  #         key: ${{ runner.os }}-${{ matrix.environment.target }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+  #     - name: Run tests
+  #       run: cargo test --verbose
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         target: ${{ matrix.environment.target }}
+  #         override: true
+  #     - name: Install system packages
+  #       if: matrix.environment.packages
+  #       run: |
+  #           sudo apt-get update;
+  #           sudo apt-get install -qq ${{ matrix.environment.packages }};
+  #     - uses: actions-rs/cargo@v1
+  #       with:
+  #         use-cross: ${{ matrix.environment.cross }}
+  #         command: build
+  #         args: --release --target ${{ matrix.environment.target }} --verbose
 
   coverage:
-    needs:
-      - linting
-      - test
+    # needs:
+    #   - linting
+    #   - test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -94,6 +94,7 @@ jobs:
       - uses: actions-rs/grcov@v0.1
       - name: Show created coverage file
         run: |
+          echo "${{ steps.coverage.outputs.report }}"
           ls -al ${{ steps.coverage.outputs.report }}
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,3 +69,29 @@ jobs:
           use-cross: ${{ matrix.environment.cross }}
           command: build
           args: --release --target ${{ matrix.environment.target }} --verbose
+
+  coverage:
+    needs:
+      - linting
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clean
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features --no-fail-fast
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
+      - uses: actions-rs/grcov@v0.1
+      - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,7 +91,8 @@ jobs:
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
-      - uses: actions-rs/grcov@v0.1
+      - id: coverage
+        uses: actions-rs/grcov@v0.1
       - name: Show created coverage file
         run: |
           echo "${{ steps.coverage.outputs.report }}"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,8 +79,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install perftools
         run: |
-          apt-get update
-          apt-get install -y libgoogle-perftools-dev
+          sudo apt-get update
+          sudo apt-get install -y libgoogle-perftools-dev
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,6 +92,9 @@ jobs:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
       - uses: actions-rs/grcov@v0.1
+      - name: Show created coverage file
+        run: |
+          ls -al ${{ steps.coverage.outputs.report }}
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,71 +9,71 @@ on:
 
 jobs:
 
-  # linting:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Clippy
-  #       run: |
-  #         rustup component add clippy
-  #         cargo clippy --all-targets --all-features -- -D warnings
-  #     - name: Rustfmt
-  #       run: cargo fmt -- --check
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Clippy
+        run: |
+          rustup component add clippy
+          cargo clippy --all-targets --all-features -- -D warnings
+      - name: Rustfmt
+        run: cargo fmt -- --check
 
-  # test:
-  #   needs:
-  #     - linting
-  #   strategy:
-  #     matrix:
-  #       environment:
-  #         - os: "ubuntu-18.04"
-  #           target: "x86_64-unknown-linux-gnu"
-  #           cross: true
-  #         - os: "macos-10.15"
-  #           target: "x86_64-apple-darwin"
-  #           cross: true
-  #         - os: "ubuntu-18.04"
-  #           target: "x86_64-pc-windows-gnu"
-  #           cross: true
-  #           packages: "gcc-mingw-w64"
-  #         - os: "ubuntu-18.04"
-  #           target: "armv7-unknown-linux-gnueabihf"
-  #           cross: true
-  #           packages: "gcc-arm-linux-gnueabihf"
-  #   runs-on: "${{ matrix.environment.os }}"
-  #   name: "${{ matrix.environment.os }} (${{ matrix.environment.target }})"
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/cache@v1
-  #       with:
-  #         path: ~/.cargo/registry
-  #         key: ${{ runner.os }}-${{ matrix.environment.target }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-  #     - uses: actions/cache@v1
-  #       with:
-  #         path: target
-  #         key: ${{ runner.os }}-${{ matrix.environment.target }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-  #     - name: Run tests
-  #       run: cargo test --verbose
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         target: ${{ matrix.environment.target }}
-  #         override: true
-  #     - name: Install system packages
-  #       if: matrix.environment.packages
-  #       run: |
-  #           sudo apt-get update;
-  #           sudo apt-get install -qq ${{ matrix.environment.packages }};
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         use-cross: ${{ matrix.environment.cross }}
-  #         command: build
-  #         args: --release --target ${{ matrix.environment.target }} --verbose
+  test:
+    needs:
+      - linting
+    strategy:
+      matrix:
+        environment:
+          - os: "ubuntu-18.04"
+            target: "x86_64-unknown-linux-gnu"
+            cross: true
+          - os: "macos-10.15"
+            target: "x86_64-apple-darwin"
+            cross: true
+          - os: "ubuntu-18.04"
+            target: "x86_64-pc-windows-gnu"
+            cross: true
+            packages: "gcc-mingw-w64"
+          - os: "ubuntu-18.04"
+            target: "armv7-unknown-linux-gnueabihf"
+            cross: true
+            packages: "gcc-arm-linux-gnueabihf"
+    runs-on: "${{ matrix.environment.os }}"
+    name: "${{ matrix.environment.os }} (${{ matrix.environment.target }})"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-${{ matrix.environment.target }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-${{ matrix.environment.target }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run tests
+        run: cargo test --verbose
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.environment.target }}
+          override: true
+      - name: Install system packages
+        if: matrix.environment.packages
+        run: |
+            sudo apt-get update;
+            sudo apt-get install -qq ${{ matrix.environment.packages }};
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.environment.cross }}
+          command: build
+          args: --release --target ${{ matrix.environment.target }} --verbose
 
   coverage:
-    # needs:
-    #   - linting
-    #   - test
+    needs:
+      - linting
+      - test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -93,10 +93,6 @@ jobs:
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
       - id: coverage
         uses: actions-rs/grcov@v0.1
-      - name: Show created coverage file
-        run: |
-          echo "${{ steps.coverage.outputs.report }}"
-          ls -al ${{ steps.coverage.outputs.report }}
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,6 +77,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install perftools
+        run: |
+          apt-get update
+          apt-get install -y libgoogle-perftools-dev
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # jwtinfo
 
 [![build badge](https://github.com/lmammino/jwtinfo/workflows/Rust/badge.svg)](https://github.com/lmammino/jwtinfo/actions?query=workflow%3ARust)
+[![codecov](https://codecov.io/gh/lmammino/jwtinfo/branch/master/graph/badge.svg)](https://codecov.io/gh/lmammino/jwtinfo)
 [![crates.io badge](https://img.shields.io/crates/v/jwtinfo.svg)](https://crates.io/crates/jwtinfo)
 [![rustc badge](https://img.shields.io/badge/rustc-1.40+-lightgray.svg)](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html)
 [![Clippy Linting Result](https://img.shields.io/badge/clippy-<3-yellowgreen)](https://github.com/rust-lang/rust-clippy)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ grcov ./target/debug/ -s . -t html --llvm --branch --ignore-not-existing -o ./ta
 Finally you will have your browsable coverage report at `./target/debug/coverage/index.html`.
 
 
+### Tarpaulin coverage
+
+Since `grcov` tends to be somewhat inaccurate at times, you can also get a coverage report by running [tarpaulin](https://github.com/xd009642/tarpaulin) using docker:
+
+```bash
+docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:develop-nightly bash -c 'cargo build && cargo tarpaulin -o Html'
+```
+
+Your coverage report will be available as `tarpaulin-report.html` in the root of the project.
+
+
 ## Credits
 
 A special thank you goes to the [Rust Reddit community](https://www.reddit.com/r/rust/) for providing a lot of useful suggestions on how to improve this project. A special thanks goes to: [mardiros](https://www.reddit.com/user/mardiros/), [matthieum](https://www.reddit.com/user/matthieum/), [steveklabnik1](https://www.reddit.com/user/steveklabnik1/), [ESBDB](https://www.reddit.com/user/ESBDB/), [Dushistov](https://www.reddit.com/user/Dushistov/), [Doddzilla7](https://www.reddit.com/user/Doddzilla7/). Another huge thank you goes to the [Rust stackoverflow community](https://chat.stackoverflow.com/rooms/62927/rust), especially to [Denys Séguret](https://chat.stackoverflow.com/users/263525).

--- a/README.md
+++ b/README.md
@@ -52,9 +52,44 @@ At this point `jwtinfo` will be available as a binary in your system.
 Pre-compiled binaries for x64 (Windows, MacOs and Unix) and ARMv7 are available in the [Releases](https://github.com/lmammino/jwtinfo/releases) page.
 
 
-## Alternatives
+#### Alternatives
 
 If you don't want to install a binary for debugging JWT tokens, a super simple `bash` alternative called [`jwtinfo.sh`](https://gist.github.com/lmammino/920ee0699af627a3492f86c607c859f6) is available.
+
+
+## Coverage reports
+
+If you want to run coverage reports locally you can follow this recipe.
+
+First of all you will need Rust Nightly that you can get with `rustup`
+
+```bash
+rustup install nightly
+```
+
+You will also need `grcov` that you can get with `cargo`:
+
+```bash
+cargo install grcov
+```
+
+Now you can run the tests in profile mode:
+
+```bash
+export CARGO_INCREMENTAL=0
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"
+cargo +nightly test
+```
+
+This will run your tests and generate coverage info in `./target/debug/`
+
+Now we can run `grcov`:
+
+```bash
+grcov ./target/debug/ -s . -t html --llvm --branch --ignore-not-existing -o ./target/debug/coverage/
+```
+
+Finally you will have your browsable coverage report at `./target/debug/coverage/index.html`.
 
 
 ## Credits

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no

--- a/src/jwt/test.rs
+++ b/src/jwt/test.rs
@@ -52,3 +52,33 @@ fn assert_parse_token_fails_due_to_more_then_three_fragment() {
         jwt_token.unwrap_err().to_string()
     );
 }
+
+#[test]
+fn assert_parse_token_fails_due_to_missing_body() {
+    let token = String::from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
+    let jwt_token = parse_token(&token);
+    assert_eq!(
+        String::from("Invalid Body: Missing token section"),
+        jwt_token.unwrap_err().to_string()
+    );
+}
+
+#[test]
+fn assert_parse_token_fails_due_to_missing_signature() {
+    let token = String::from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ");
+    let jwt_token = parse_token(&token);
+    assert_eq!(
+        String::from("Invalid Signature: Missing token section"),
+        jwt_token.unwrap_err().to_string()
+    );
+}
+
+#[test]
+fn assert_parse_token_fails_due_invalid_json_header() {
+    let token = String::from("eyJhbGc6ICJIUzI1NiIsInR5cCI6ICJKV1QifQ.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU");
+    let jwt_token = parse_token(&token);
+    assert!(jwt_token
+        .unwrap_err()
+        .to_string()
+        .starts_with("Invalid Header: JSON error"));
+}


### PR DESCRIPTION
Ref #14 

Adds automated run of coverage after all tests are done and sends the report to [codecov](https://codecov.io/gh/lmammino/jwtinfo/).

Example here: https://codecov.io/gh/lmammino/jwtinfo/branch/feature%2Fcoverage-reports


### TODO

 - [x] Add instructions on the readme on how to generate coverage reports manually
 - [x] Try to bump coverage a bit