### PR TITLE
Implements from_str trait for Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ assert_eq!(token.header.alg, "HS256");
 assert_eq!(token.body, "{\"sub\":\"1234567890\",\"name\":\"John Doe\",\"iat\":1516239022}");
 ```
 
+Since `jwt:Token` implements `str::FromStr`, you can also do the following:
+
+```rust
+use jwtinfo::{jwt};
+let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c".parse::<jwt::Token>().unwrap();
+assert_eq!(token.header.alg, "HS256");
+assert_eq!(token.body, "{\"sub\":\"1234567890\",\"name\":\"John Doe\",\"iat\":1516239022}");
+```
+
 
 ## Coverage reports
 

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -19,6 +19,16 @@
 //!   Err(e) => panic!(e)
 //! }
 //! ```
+//!
+//! Since `jwt::Token` implements `str::FromStr`, you can also do the following:
+//!
+//! ```rust
+//! use jwtinfo::{jwt};
+//!
+//! let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c".parse::<jwt::Token>().unwrap();
+//! assert_eq!(token.header.alg, "HS256");
+//! assert_eq!(token.body, "{\"sub\":\"1234567890\",\"name\":\"John Doe\",\"iat\":1516239022}");
+//! ```
 
 use serde::Deserialize;
 use std::error::Error;

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -61,6 +61,14 @@ impl Token {
     }
 }
 
+impl str::FromStr for Token {
+    type Err = JWTParsePartError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse(s)
+    }
+}
+
 /// Represents an error while parsing a JWT token
 #[derive(Debug)]
 pub enum JWTParseError {

--- a/src/jwt/test.rs
+++ b/src/jwt/test.rs
@@ -9,6 +9,13 @@ fn assert_parse_successfully() {
 }
 
 #[test]
+fn assert_parse_successfullt_from_str() {
+    let token = String::from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA");
+    let jwt_token = token.parse::<Token>();
+    assert_eq!(String::from("{\"foo\":\"bar\"}"), jwt_token.unwrap().body);
+}
+
+#[test]
 fn assert_parse_fails_due_to_invalid_header() {
     let token = String::from(
         "invalid_header.eyJmb28iOiJiYXIifQ.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA",


### PR DESCRIPTION
This change allows for the following syntax (parsing a token directly from a string):

```rust
"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA".parse::<Token>();
```