### PR TITLE
Allows displaying the header part using the `--header` flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ Which will print:
 {"sub":"1234567890","name":"John Doe","iat":1516239022}
 ```
 
+If you want to visualize the token header (rather than the body), you can do that by passing the `--header` flag:
+
+```bash
+jwtinfo --header eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+```
+
+Which will print:
+
+```json
+{"alg":"HS256","typ":"JWT"}
+```
+
 You can combine the tool with other command line utilities, for instance [`jq`](https://stedolan.github.io/jq/):
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,7 +37,7 @@ fn main() -> io::Result<()> {
         }
     };
 
-    println!("{}", jwt_token.body);
+    println!("{}", jwt_token.body.to_string());
 
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,14 @@ fn main() -> io::Result<()> {
         .version(env!("CARGO_PKG_VERSION"))
         .about("Shows information about a JWT token")
         .arg(
+            Arg::with_name("header")
+                .short("H")
+                .long("header")
+                .help("Shows the token header rather than the body")
+                .required(false)
+                .takes_value(false),
+        )
+        .arg(
             Arg::with_name("token")
                 .help("the JWT token as a string (use \"-\" to read from stdin)")
                 .required(true)
@@ -37,7 +45,11 @@ fn main() -> io::Result<()> {
         }
     };
 
-    println!("{}", jwt_token.body.to_string());
+    if matches.is_present("header") {
+        println!("{}", jwt_token.header.to_string());
+    } else {
+        println!("{}", jwt_token.body.to_string());
+    }
 
     Ok(())
 }

--- a/src/jwt/test.rs
+++ b/src/jwt/test.rs
@@ -4,15 +4,29 @@ use super::*;
 #[test]
 fn assert_parse_successfully() {
     let token = String::from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA");
-    let jwt_token = parse(&token);
-    assert_eq!(String::from("{\"foo\":\"bar\"}"), jwt_token.unwrap().body);
+    let jwt_token = parse(&token).unwrap();
+    assert_eq!(
+        String::from("{\"alg\":\"HS256\",\"typ\":\"JWT\"}"),
+        jwt_token.header.to_string()
+    );
+    assert_eq!(
+        String::from("{\"foo\":\"bar\"}"),
+        jwt_token.body.to_string()
+    );
 }
 
 #[test]
 fn assert_parse_successfullt_from_str() {
     let token = String::from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA");
-    let jwt_token = token.parse::<Token>();
-    assert_eq!(String::from("{\"foo\":\"bar\"}"), jwt_token.unwrap().body);
+    let jwt_token = token.parse::<Token>().unwrap();
+    assert_eq!(
+        String::from("{\"alg\":\"HS256\",\"typ\":\"JWT\"}"),
+        jwt_token.header.to_string()
+    );
+    assert_eq!(
+        String::from("{\"foo\":\"bar\"}"),
+        jwt_token.body.to_string()
+    );
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,8 @@
 //! use jwtinfo::{jwt};
 //!
 //! let token = jwt::parse("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c").unwrap();
-//! assert_eq!(token.header.alg, "HS256");
-//! assert_eq!(token.body, "{\"sub\":\"1234567890\",\"name\":\"John Doe\",\"iat\":1516239022}");
+//! assert_eq!(token.header.to_string(), "{\"alg\":\"HS256\",\"typ\":\"JWT\"}");
+//! assert_eq!(token.body.to_string(), "{\"iat\":1516239022,\"name\":\"John Doe\",\"sub\":\"1234567890\"}");
 //! ```
 
 pub mod jwt;


### PR DESCRIPTION
Allows displaying the header using the `--header` flag.

For instance:

```bash
jwtinfo --header eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
```

will print:

```json
{"alg":"HS256","typ":"JWT"}
```

While doing this, the internal representation of the `jwt::Token` was changed to have `header` and `body` be `serde_json::Value` types rather than `jwt::Header` and `string` types.

Closes #24 