### PR TITLE
Improve tests and support every type that can be converted to string in jwt::parse

### DIFF
--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -183,8 +183,8 @@ fn parse_signature(raw_signature: Option<&str>) -> Result<Vec<u8>, JWTParseError
 /// # Errors
 ///
 /// This function will return a `JWTParsePartError` if the token cannot be successfully parsed
-pub fn parse(token: &str) -> Result<Token, JWTParsePartError> {
-    let mut parts = token.split('.');
+pub fn parse<T: AsRef<str>>(token: T) -> Result<Token, JWTParsePartError> {
+    let mut parts = token.as_ref().split('.');
     let header = parse_header(parts.next()).map_err(JWTParsePartError::Header)?;
     let body = parse_body(parts.next()).map_err(JWTParsePartError::Body)?;
     let signature = parse_signature(parts.next()).map_err(JWTParsePartError::Signature)?;

--- a/src/jwt/test.rs
+++ b/src/jwt/test.rs
@@ -4,28 +4,28 @@ use super::*;
 #[test]
 fn assert_parse_successfully() {
     let token = String::from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA");
-    let jwt_token = parse(&token).unwrap();
+    let parsed_token = parse(&token).unwrap();
     assert_eq!(
         String::from("{\"alg\":\"HS256\",\"typ\":\"JWT\"}"),
-        jwt_token.header.to_string()
+        parsed_token.header.to_string()
     );
     assert_eq!(
         String::from("{\"foo\":\"bar\"}"),
-        jwt_token.body.to_string()
+        parsed_token.body.to_string()
     );
 }
 
 #[test]
 fn assert_parse_successfullt_from_str() {
     let token = String::from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA");
-    let jwt_token = token.parse::<Token>().unwrap();
+    let parsed_token = token.parse::<Token>().unwrap();
     assert_eq!(
         String::from("{\"alg\":\"HS256\",\"typ\":\"JWT\"}"),
-        jwt_token.header.to_string()
+        parsed_token.header.to_string()
     );
     assert_eq!(
         String::from("{\"foo\":\"bar\"}"),
-        jwt_token.body.to_string()
+        parsed_token.body.to_string()
     );
 }
 
@@ -34,8 +34,8 @@ fn assert_parse_fails_due_to_invalid_header() {
     let token = String::from(
         "invalid_header.eyJmb28iOiJiYXIifQ.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA",
     );
-    let jwt_token = parse(&token);
-    assert!(jwt_token
+    let parsed_token = parse(&token);
+    assert!(parsed_token
         .unwrap_err()
         .to_string()
         .starts_with("Invalid Header:"));
@@ -46,8 +46,8 @@ fn assert_parse_fails_due_to_invalid_body() {
     let token = String::from(
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.invalid_body.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA",
     );
-    let jwt_token = parse(&token);
-    assert!(jwt_token
+    let parsed_token = parse(&token);
+    assert!(parsed_token
         .unwrap_err()
         .to_string()
         .starts_with("Invalid Body:"));
@@ -57,8 +57,8 @@ fn assert_parse_fails_due_to_invalid_body() {
 fn assert_parse_fails_due_to_invalid_signature() {
     let token =
         String::from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.invalid_signature");
-    let jwt_token = parse(&token);
-    assert!(jwt_token
+    let parsed_token = parse(&token);
+    assert!(parsed_token
         .unwrap_err()
         .to_string()
         .starts_with("Invalid Signature:"));
@@ -67,39 +67,95 @@ fn assert_parse_fails_due_to_invalid_signature() {
 #[test]
 fn assert_parse_fails_due_to_more_then_three_fragment() {
     let token = String::from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA.one_more_fragment");
-    let jwt_token = parse(&token);
+    let parsed_token = parse(&token);
     assert_eq!(
         String::from("Error: Unexpected fragment after signature"),
-        jwt_token.unwrap_err().to_string()
+        parsed_token.unwrap_err().to_string()
     );
 }
 
 #[test]
 fn assert_parse_fails_due_to_missing_body() {
     let token = String::from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
-    let jwt_token = parse(&token);
+    let parsed_token = parse(&token);
     assert_eq!(
         String::from("Invalid Body: Missing token section"),
-        jwt_token.unwrap_err().to_string()
+        parsed_token.unwrap_err().to_string()
     );
 }
 
 #[test]
 fn assert_parse_fails_due_to_missing_signature() {
     let token = String::from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ");
-    let jwt_token = parse(&token);
+    let parsed_token = parse(&token);
     assert_eq!(
         String::from("Invalid Signature: Missing token section"),
-        jwt_token.unwrap_err().to_string()
+        parsed_token.unwrap_err().to_string()
     );
 }
 
 #[test]
 fn assert_parse_fails_due_invalid_json_header() {
     let token = String::from("eyJhbGc6ICJIUzI1NiIsInR5cCI6ICJKV1QifQ.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU");
-    let jwt_token = parse(&token);
-    assert!(jwt_token
-        .unwrap_err()
-        .to_string()
-        .starts_with("Invalid Header: JSON error"));
+    let parsed_token = parse(&token);
+    let err = format!("{}", parsed_token.unwrap_err());
+    assert!(err.starts_with("Invalid Header: JSON error"));
+}
+
+#[test]
+fn assert_parse_fail_due_invalid_json_body() {
+    let token = String::from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXJ9.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU");
+    let parsed_token = parse(&token);
+    let err = format!("{}", parsed_token.unwrap_err());
+    assert!(err.starts_with("Invalid Body: JSON error"));
+}
+
+#[test]
+fn assert_fails_with_non_base64_header() {
+    let token = String::from(
+        "ĄČĘĖĮŠŲŪąčęėįšųū\x09#$#434.eyJmb28iOiJiYXIifQ.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA",
+    );
+    let parsed_token = parse(&token);
+    let err = format!("{}", parsed_token.unwrap_err());
+    assert_eq!(
+        err,
+        "Invalid Header: Base64 error, Invalid byte 196, offset 0."
+    );
+}
+
+#[test]
+fn assert_fails_with_non_base64_body() {
+    let token = String::from(
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ĄČĘĖĮŠŲŪąčęėįšųū\x09#$#434.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA",
+    );
+    let parsed_token = parse(&token);
+    let err = format!("{}", parsed_token.unwrap_err());
+    assert_eq!(
+        err,
+        "Invalid Body: Base64 error, Invalid byte 196, offset 0."
+    );
+}
+
+#[test]
+fn assert_fails_with_non_base64_signature() {
+    let token = String::from(
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.ĄČĘĖĮŠŲŪąčęėįšųū\x09#$#434",
+    );
+    let parsed_token = parse(&token);
+    let err = format!("{}", parsed_token.unwrap_err());
+    assert_eq!(
+        err,
+        "Invalid Signature: Base64 error, Invalid byte 196, offset 0."
+    );
+}
+
+#[test]
+fn assert_fails_with_non_valid_token() {
+    let token = String::from(r"I'm \x00\x09writing \x52\x75\x73\x74!\x00\x09");
+    let parsed_token = parse(&token);
+    let err = format!("{}", parsed_token.unwrap_err());
+    assert_eq!(
+        err,
+        "Invalid Header: Base64 error, Encoded text cannot have a 6-bit remainder."
+    );
 }

--- a/src/jwt/test.rs
+++ b/src/jwt/test.rs
@@ -159,3 +159,16 @@ fn assert_fails_with_non_valid_token() {
         "Invalid Header: Base64 error, Encoded text cannot have a 6-bit remainder."
     );
 }
+
+#[test]
+fn assert_fails_with_token_from_invalid_lossy_utf8() {
+    let token = String::from_utf8_lossy(
+        b"\x00\x09\x52\x09\x00\x75\x00\x09\x73\x00\x09\x74\x00\x09\x00\x09",
+    );
+    let parsed_token = parse(&token);
+    let err = format!("{}", parsed_token.unwrap_err());
+    assert_eq!(
+        err,
+        "Invalid Header: Base64 error, Invalid byte 0, offset 0."
+    );
+}


### PR DESCRIPTION
Checks for more error cases in tests

Also `jwt::parse()` now accepts any type that can be converted to a string using `AsRef<str>`