### PR TITLE
Potential approach to #30 (and misc. fixes)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,8 +2,7 @@ use clap::{Arg, ArgAction, Command};
 use serde_json::to_string_pretty;
 use std::io::{self, Read};
 use std::process;
-
-mod jwt;
+use jwtinfo::jwt;
 
 #[doc(hidden)]
 fn main() -> io::Result<()> {
@@ -28,6 +27,11 @@ fn main() -> io::Result<()> {
         .get_matches();
 
     let should_pretty_print = matches.get_flag("pretty");
+
+    if !matches.get_one::<String>("token").is_some() {
+        eprintln!("Error: No token provided, see --help for usage");
+        process::exit(1);
+    }
 
     let mut token = matches.get_one::<String>("token").unwrap().clone();
     let mut buffer = String::new();

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -131,6 +131,12 @@ pub enum JWTParsePartError {
     Body(JWTParseError),
     /// Error while parsing the Signature part
     Signature(JWTParseError),
+    /// Error while parsing the Encryption Key of a JWE
+    EncryptionKey(JWTParseError),
+    /// Error while parsing the Encryption IV of a JWE
+    EncryptionIV(JWTParseError),
+    /// Error while parsing the Authentication Tag of a JWE
+    AuthenticationTag(JWTParseError),
     /// Error because an additional part was found after the Signature part
     UnexpectedPart(),
 }
@@ -141,6 +147,9 @@ impl fmt::Display for JWTParsePartError {
             JWTParsePartError::Header(e) => format!("Invalid Header: {}", e),
             JWTParsePartError::Body(e) => format!("Invalid Body: {}", e),
             JWTParsePartError::Signature(e) => format!("Invalid Signature: {}", e),
+            JWTParsePartError::EncryptionKey(e) => format!("Invalid Encryption Key: {}", e),
+            JWTParsePartError::EncryptionIV(e) => format!("Invalid Encryption IV: {}", e),
+            JWTParsePartError::AuthenticationTag(e) => format!("Invalid Authentication Tag: {}", e),
             JWTParsePartError::UnexpectedPart() => {
                 "Error: Unexpected fragment after signature".to_string()
             }
@@ -188,6 +197,32 @@ fn parse_signature(raw_signature: Option<&str>) -> Result<Vec<u8>, JWTParseError
     }
 }
 
+#[doc(hidden)]
+fn parse_encryption_key(raw_encryption_key: Option<&str>) -> Result<Vec<u8>, JWTParseError> {
+    match raw_encryption_key {
+        None => Err(JWTParseError::MissingSection()),
+        Some(s) => Ok(get_base64().decode(s)?),
+    }
+}
+
+#[doc(hidden)]
+fn parse_encryption_iv(raw_encryption_iv: Option<&str>) -> Result<Vec<u8>, JWTParseError> {
+    match raw_encryption_iv {
+        None => Err(JWTParseError::MissingSection()),
+        Some(s) => Ok(get_base64().decode(s)?),
+    }
+}
+
+#[doc(hidden)]
+fn parse_authentication_tag(
+    raw_authentication_tag: Option<&str>,
+) -> Result<Vec<u8>, JWTParseError> {
+    match raw_authentication_tag {
+        None => Err(JWTParseError::MissingSection()),
+        Some(s) => Ok(get_base64().decode(s)?),
+    }
+}
+
 /// Parses a token from a string
 ///
 /// # Errors
@@ -196,14 +231,39 @@ fn parse_signature(raw_signature: Option<&str>) -> Result<Vec<u8>, JWTParseError
 pub fn parse<T: AsRef<str>>(token: T) -> Result<Token, JWTParsePartError> {
     let mut parts = token.as_ref().split('.');
     let header = parse_header(parts.next()).map_err(JWTParsePartError::Header)?;
-    let body = parse_body(parts.next()).map_err(JWTParsePartError::Body)?;
-    let signature = parse_signature(parts.next()).map_err(JWTParsePartError::Signature)?;
+    if header.get("enc").is_some() {
+        // TODO attempt to decrypt the body using the algorithm specified in the header
+        // and a key provided by argument
+        let _encryption_key =
+            parse_encryption_key(parts.next()).map_err(JWTParsePartError::EncryptionKey)?;
+        let _encryption_iv =
+            parse_encryption_iv(parts.next()).map_err(JWTParsePartError::EncryptionIV)?;
+        let _encrypted_body = parts.next().unwrap();
+        let _authentication_tag =
+            parse_authentication_tag(parts.next()).map_err(JWTParsePartError::AuthenticationTag)?;
 
-    if parts.next().is_some() {
-        return Err(JWTParsePartError::UnexpectedPart());
+        if parts.next().is_some() {
+            return Err(JWTParsePartError::UnexpectedPart());
+        }
+
+        // For now (and eventually if no key is provided),
+        // return a token with the header and a dummy value
+        // for the body
+        Ok(Token::new(
+            header,
+            serde_json::Value::from("encrypted"),
+            Vec::new(),
+        ))
+    } else {
+        let body = parse_body(parts.next()).map_err(JWTParsePartError::Body)?;
+        let signature = parse_signature(parts.next()).map_err(JWTParsePartError::Signature)?;
+
+        if parts.next().is_some() {
+            return Err(JWTParsePartError::UnexpectedPart());
+        }
+
+        Ok(Token::new(header, body, signature))
     }
-
-    Ok(Token::new(header, body, signature))
 }
 
 #[cfg(test)]

--- a/src/jwt/test.rs
+++ b/src/jwt/test.rs
@@ -16,7 +16,7 @@ fn assert_parse_successfully() {
 }
 
 #[test]
-fn assert_parse_successfullt_from_str() {
+fn assert_parse_successfully_from_str() {
     let token = String::from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA");
     let parsed_token = token.parse::<Token>().unwrap();
     assert_eq!(

--- a/src/jwt/test.rs
+++ b/src/jwt/test.rs
@@ -172,3 +172,17 @@ fn assert_fails_with_token_from_invalid_lossy_utf8() {
         "Invalid Header: Base64 error, Invalid byte 0, offset 0."
     );
 }
+
+#[test]
+fn assert_parse_jwe_with_dummy_body() {
+    let token = String::from("eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZDQkMtSFM1MTIiLCJraWQiOiIxOGIxY2Y3NThjMWQ0ZWM2YmRhNjU4OTM1N2FiZGQ4NSIsInR5cCI6IkpXVCIsImN0eSI6IkpXVCJ9.gCbxP78o3DgpDTUQbuHniuGgYpATqgGkRGy7paC6hRrz7N7eIa6sAOWDO9Fhnj-c8ocMl4cF4Jb_mv5qRPCh9r57PBqx7jOhMIMPTwJGpjcyBaqtHlZlu1vupY5tQ3Y2jGz1Ti4BnywaeEHPyIPQJtN7F7hIAORzj7IY4sIKkVXtQJZgaKW8pEHq_GCqj8i5aaiM0uJnRG3GOh3livp9Npjv9doqp3gyPa1zjrg2H1RsOGn0j2QMGvtuVfkuNwF-SoPKFECyHOq0ZK1oH2sTO8-JwvHflbIZQr5xWTpS8q7MbUXEuqURtrg0Tj-2z6tdaOLT4b3UeDufK2ar3bBfRD4-nRALtoY0ekcMyGFOS7o1Mxl3hy5sIG-EySyWeuBVy68aDWDpi9qZoQuY1TbxxakjncCOGu_Gh1l1m_mK2l_IdyXCT_GCfzFq4ZTkPZ5eydNBAPZuxBLUb4BrMb5iDdZjT7AgGOlRre_wIRHmmKm8W9nDeQQRmbIXO23JuOw9.BDCarfq2r_Uk8DHNfsNwSQ.4DuQx1cfJXadHnudrVaBss45zxyd6iouuSzZUyOeM4ikF_7hDOgwmaCma-Z97_QZBJ5DzVn9SJhKUTAqpVR3BRGAxJ_HAXU5jaTjXqbvUaxsh7Z5TgZ9eck0FIoe1lkwv51xEvYqqQ_Xojr4MAEmLuME_9ArCK9mNaMADIzOj4VoQtaDP1l26ytocc-oENifBRYGu28LbJLkyQKzyQy6FuAOtWjLM0WCXV7-o_dvj6qfeYHNBD7YBSxyqdgD8dcxMBNd2sK73YsZPHEa0V1-8zz7hm3bH3tZelpwPWScqLLW_SUH586c0FVeI6ggvqzjfLZ_Y6eQibVSdXfOtJBk22QrLsuCXbRK8G1w9t23Pwu8ukUAw4v0l7HeaW_0SJyKSPQANRP83MyFbK7fmzTYaW9TYN2JrKN-PLpd2dIFSm2Ga_EfaCwNJBm4RDMzDNrf-O0AissvYyHb0WaALiCiFCogliYqLzRB6xDb-b4964M.J7WDOFLRRPJ7lLpTfN2mOiXLDg5xtaF-sLQ4mOeN5oc");
+
+    let parsed_token = parse(token).unwrap();
+
+    assert_eq!(
+        String::from("{\"alg\":\"RSA-OAEP\",\"cty\":\"JWT\",\"enc\":\"A256CBC-HS512\",\"kid\":\"18b1cf758c1d4ec6bda6589357abdd85\",\"typ\":\"JWT\"}"),
+        String::from(parsed_token.header.to_string()),
+    );
+
+    assert_eq!(String::from("\"encrypted\""), parsed_token.body.to_string());
+}


### PR DESCRIPTION
- Resolves #30

Sets up for future support for actually interpreting and decrypting JWE tokens, for now at least doesn't panic when given one. Also fixes a typo, and adds a more user-friendly message if you invoke the programme without a token or stdin '-' argument.

thoughts?